### PR TITLE
Readers are also counted as processes which fix a bug when we sweep allocated data

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,22 @@
 # Bancos, a simple KV-store
 
+`bancos` is a KV store, meaning that it can associate a string with a number
+(which can refer to a value). This KV store is persistent (meaning that it is
+saved in a file or block device) and the structure can be manipulated by
+several programs in parallel:
+- the structure used is [ROWEX][rowex]
+- persistence comes from [P-ART][p-art]
+
+`bancos` is therefore the first step in a database system capable of inserting
+(in parallel) new values or searching (also in parallel) for existing values
+according to a key.
+
+The implementation of `bancos` does not depend on any particular scheduler, but
+we recommend using `bancos` with [miou][miou] to enable parallelization of
+readers and writers.
+
+## Tools
+
 A simple example:
 ```sh
 $ git clone https://github.com/robur-coop/bancos.git

--- a/bancos.opam
+++ b/bancos.opam
@@ -17,6 +17,7 @@ depends: [
   "fpath" {>= "0.7.3"}
   "hxd" {>= "0.3.2"}
   "miou" {>= "0.2"}
+  "rowex" {= version}
 ]
 available:
   arch != "ppc64" & arch != "arm32" & arch != "x86_32" & arch != "s390x"

--- a/bank.opam
+++ b/bank.opam
@@ -15,6 +15,7 @@ depends: [
   "logs" {>= "0.7.0"}
   "crowbar" {>= "0.2"}
   "hxd" {>= "0.3.2"}
+  "rowex" {= version}
 ]
 available:
   arch != "ppc64" & arch != "arm32" & arch != "x86_32" & arch != "s390x"

--- a/bin/sdb.ml
+++ b/bin/sdb.ml
@@ -7,21 +7,22 @@ type command =
 let execute ?(quiet = false) commands filepath size =
   Miou.run ~domains:0 @@ fun () ->
   let t = Part.from_system ~size filepath in
-  let reader = Part.reader t in
   let rec go n =
     match commands () with
     | None -> if not quiet then Fmt.pr "db: %d action(s) committed\n%!" n
     | Some Noop -> go n
-    | Some (Lookup key) -> begin
-        match Part.lookup reader key with
-        | value ->
-            if not quiet then Fmt.pr "%S => %d\n%!" (key :> string) value;
-            Logs.info (fun m -> m "%S => %d" (key :> string) value);
-            go (succ n)
-        | exception Not_found ->
-            Logs.err (fun m -> m "%S does not exist" (key :> string));
-            raise Not_found
-      end
+    | Some (Lookup key) ->
+        let () =
+          Part.reader t @@ fun reader ->
+          match Part.lookup reader key with
+          | value ->
+              if not quiet then Fmt.pr "%S => %d\n%!" (key :> string) value;
+              Logs.info (fun m -> m "%S => %d" (key :> string) value)
+          | exception Not_found ->
+              Logs.err (fun m -> m "%S does not exist" (key :> string));
+              raise Not_found
+        in
+        go (succ n)
     | Some (Insert (key, value)) ->
         let[@warning "-8"] (Ok ()) =
           Part.writer t @@ fun writer ->

--- a/lib/bancos.ml
+++ b/lib/bancos.ml
@@ -86,7 +86,7 @@ let do_wrs ~uid t wrs =
       Log.err (fun m -> m "[%02x] failed with %S" uid (Printexc.to_string exn))
 
 let do_rds t rds =
-  let reader = Part.reader t.part in
+  Part.reader t.part @@ fun reader ->
   let do_rd = function
     | Lookup (key, res) -> begin
         match Part.lookup reader key with

--- a/lib/part.c
+++ b/lib/part.c
@@ -360,6 +360,11 @@ void dc_cvac_range(const void *ptr, uint64_t len) {
   }
 }
 
+/* Please note that the instruction below ensures that the changes made by the
+ * core are visible to others, but it does not guarantee that the [dc cvac] has
+ * completed successfully: we cannot guarantee effective persistence (and if
+ * the software crashes immediately afterward, the data may **not have been
+ * saved**). */
 void sfence() { __asm__ volatile("dmb ishst" ::: "memory"); }
 
 CAMLprim value caml_persist(value memory, value addr, value len) {

--- a/lib/part.ml
+++ b/lib/part.ml
@@ -175,13 +175,13 @@ type t = {
   ; memory : memory Atomic.t
   ; root : Rowex.rdwr Rowex.Addr.t
   ; queue_locker : Miou.Mutex.t
-  ; active_writers : int Queue.t
-  ; released_writers : Set.t ref
+  ; active_processes : (int * [ `Wr | `Rd ]) Queue.t
+  ; released_processes : Set.t ref
   ; clatch : Clatch.t option ref
   ; free_locker : Miou.Mutex.t
   ; free : (int, Set.t) Hashtbl.t
   ; free_cells : int Atomic.t
-  ; older_active_writer : int Atomic.t
+  ; older_active_process : int Atomic.t
   ; collected : cell Miou.Queue.t
   ; extend_locker : Miou.Mutex.t
   ; extend_result : memory Miou.Computation.t option ref
@@ -194,11 +194,11 @@ type writer = {
   ; free_locker : Miou.Mutex.t
   ; free : (int, Set.t) Hashtbl.t
   ; free_cells : int Atomic.t
-  ; older_active_writer : int Atomic.t
+  ; older_active_process : int Atomic.t
   ; queue_locker : Miou.Mutex.t
   ; clatch : Clatch.t option ref
-  ; active_writers : int Queue.t
-  ; released_writers : Set.t ref
+  ; active_processes : (int * [ `Wr | `Rd ]) Queue.t
+  ; released_processes : Set.t ref
   ; collected : cell Miou.Queue.t
   ; extend_locker : Miou.Mutex.t
   ; extend_result : memory Miou.Computation.t option ref
@@ -354,10 +354,10 @@ module Garbage_collector = struct
     else None
 
   let can_we_sweep_it writer uid' =
-    let older_active_writer =
-      Atomic.get (Sys.opaque_identity writer.older_active_writer)
+    let older_active_process =
+      Atomic.get (Sys.opaque_identity writer.older_active_process)
     in
-    older_active_writer = 0 || uid' < older_active_writer
+    older_active_process = 0 || uid' < older_active_process
 
   let collect writer addr ~len ~uid =
     let addr = Rowex.Addr.unsafe_to_int addr in
@@ -388,9 +388,11 @@ module Garbage_collector = struct
   exception Retry_after_extension
 
   let unsafe_count_active_writers writer =
-    let rw = !(writer.released_writers) in
-    let fn acc uid = if Set.mem uid rw then acc else acc + 1 in
-    Queue.fold fn 0 writer.active_writers
+    let rw = !(writer.released_processes) in
+    let fn acc (uid, k) =
+      match k with `Wr when not (Set.mem uid rw) -> acc + 1 | _ -> acc
+    in
+    Queue.fold fn 0 writer.active_processes
 
   let really_alloc writer ~kind len payloads =
     let memory = writer.memory in
@@ -421,14 +423,6 @@ module Garbage_collector = struct
       Miou.Mutex.lock writer.queue_locker;
       match !(writer.clatch) with
       | None ->
-          Log.debug (fun m ->
-              m "released writers: @[<hov>%a@]"
-                Fmt.(Dump.iter Set.iter (any "set") int)
-                !(writer.released_writers));
-          Log.debug (fun m ->
-              m "active writers: @[<hov>%a@]"
-                Fmt.(Dump.queue int)
-                writer.active_writers);
           let active_writers = unsafe_count_active_writers writer in
           assert (active_writers >= 1);
           let clatch = Clatch.create (active_writers - 1) in
@@ -480,7 +474,7 @@ module Garbage_collector = struct
         if kind = `Node then
           C.atomic_set_leuintnat memory (addr + Rowex._header_owner) writer.uid;
         Rowex.Addr.of_int_to_rdwr addr
-    | None -> (
+    | None -> begin
         ignore (sweep writer);
         match get_free_cell writer ~len with
         | None -> (
@@ -495,7 +489,8 @@ module Garbage_collector = struct
               C.atomic_set_leuintnat memory
                 (addr + Rowex._header_owner)
                 writer.uid;
-            Rowex.Addr.of_int_to_rdwr addr)
+            Rowex.Addr.of_int_to_rdwr addr
+      end
 end
 
 (* NOTE(dinosaure): I think it's the same implementation than [unsafe_add_free_cell]... *)
@@ -772,20 +767,20 @@ let make ~filepath memory =
   C.atomic_set_leuintnat memory 0 (size_of_word * 2);
   let clatch = ref None
   and extend_result = ref None
-  and released_writers = ref Set.empty in
+  and released_processes = ref Set.empty in
   let t : t =
     {
       filepath
     ; memory = Atomic.make memory
     ; root = Rowex.Addr.null
     ; queue_locker = Miou.Mutex.create ()
-    ; active_writers = Queue.create ()
-    ; released_writers
+    ; active_processes = Queue.create ()
+    ; released_processes
     ; clatch
     ; free_locker = Miou.Mutex.create ()
     ; free = Hashtbl.create 0x100
     ; free_cells = Atomic.make 0
-    ; older_active_writer = Atomic.make 0
+    ; older_active_process = Atomic.make 0
     ; collected = Miou.Queue.create ()
     ; extend_locker = Miou.Mutex.create ()
     ; extend_result
@@ -797,10 +792,10 @@ let make ~filepath memory =
     ; free_locker = t.free_locker
     ; free = t.free
     ; free_cells = t.free_cells
-    ; older_active_writer = t.older_active_writer
+    ; older_active_process = t.older_active_process
     ; queue_locker = t.queue_locker
-    ; active_writers = t.active_writers
-    ; released_writers
+    ; active_processes = t.active_processes
+    ; released_processes
     ; clatch
     ; collected = t.collected
     ; extend_locker = t.extend_locker
@@ -825,11 +820,11 @@ let load ~filepath memory =
     ; free_locker = Miou.Mutex.create ()
     ; free = Hashtbl.create 0x100
     ; free_cells = Atomic.make 0
-    ; older_active_writer = Atomic.make 0
+    ; older_active_process = Atomic.make 0
     ; collected = Miou.Queue.create ()
     ; queue_locker = Miou.Mutex.create ()
-    ; active_writers = Queue.create ()
-    ; released_writers = ref Set.empty
+    ; active_processes = Queue.create ()
+    ; released_processes = ref Set.empty
     ; clatch = ref None
     ; extend_locker = Miou.Mutex.create ()
     ; extend_result = ref None
@@ -851,58 +846,58 @@ let from_system ?(size = 10485760) filepath =
     let memory = Bigarray.array1_of_genarray memory in
     make ~filepath memory
 
-let reader (rowex : t) =
-  { memory = Atomic.get rowex.memory; root = Rowex.Addr.to_rdonly rowex.root }
+(* This part is how we handle processes. *)
 
 (* the goal here is to update [t.older_active_writer] to the one we get from
    [t.active_writers]. We **really try** to be synchrone between the last
    [t.active_writers] and [t.older_active_writer]. *)
-let rec update_older_active_writer ?(backoff = Miou.Backoff.default) ?older
+let rec update_older_active_process ?(backoff = Miou.Backoff.default) ?older
     (t : t) =
   let older =
     match older with
     | Some older -> older
-    | None -> (
+    | None -> begin
         Miou.Mutex.protect t.queue_locker @@ fun () ->
-        match Queue.peek t.active_writers with
-        | older -> older
-        | exception Queue.Empty -> 0)
+        match Queue.peek t.active_processes with
+        | older, _ -> older
+        | exception Queue.Empty -> 0
+      end
   in
-  let seen = Atomic.get t.older_active_writer in
+  let seen = Atomic.get t.older_active_process in
   if
     seen <> older
-    && not (Atomic.compare_and_set t.older_active_writer seen older)
-  then update_older_active_writer ~backoff:(Miou.Backoff.once backoff) t
+    && not (Atomic.compare_and_set t.older_active_process seen older)
+  then update_older_active_process ~backoff:(Miou.Backoff.once backoff) t
 
-let add_writer (t : t) ~uid =
+let add_process (t : t) kind ~uid =
   Log.debug (fun m -> m "new writer %016x" uid);
-  let set = Atomic.compare_and_set t.older_active_writer 0 uid in
+  let set = Atomic.compare_and_set t.older_active_process 0 uid in
   if not set then begin
-    let older =
+    let older, _ =
       Miou.Mutex.protect t.queue_locker @@ fun () ->
-      Queue.push uid t.active_writers;
+      Queue.push (uid, kind) t.active_processes;
       (* here, we take the previous writer before the apparition of our new one. *)
-      Queue.peek t.active_writers
+      Queue.peek t.active_processes
     in
-    update_older_active_writer ~older t
+    update_older_active_process ~older t
   end
   else
     Miou.Mutex.protect t.queue_locker @@ fun () ->
-    Queue.push uid t.active_writers
+    Queue.push (uid, kind) t.active_processes
 
-let rec unsafe_clean_released_writers (t : t) =
-  let rw = !(t.released_writers) in
+let rec unsafe_clean_released_processes (t : t) =
+  let rw = !(t.released_processes) in
   if Set.is_empty rw = false then
-    match Queue.peek t.active_writers with
-    | older ->
+    match Queue.peek t.active_processes with
+    | older, _ ->
         if Set.mem older rw then begin
-          t.released_writers := Set.remove older rw;
-          ignore (Queue.pop t.active_writers);
-          unsafe_clean_released_writers t
+          t.released_processes := Set.remove older rw;
+          ignore (Queue.pop t.active_processes);
+          unsafe_clean_released_processes t
         end
     | exception Queue.Empty -> ()
 
-let release_writer (t : t) ~uid =
+let release_process (t : t) kind ~uid =
   let older =
     Miou.Mutex.protect t.queue_locker @@ fun () ->
     Log.debug (fun m -> m "release writer %016x" uid);
@@ -910,35 +905,47 @@ let release_writer (t : t) ~uid =
        file, we count down to prevent the other writer from waiting for us
        indefinitely! *)
     let () =
-      match !(t.clatch) with
-      | Some clatch ->
+      match (kind, !(t.clatch)) with
+      | `Wr, Some clatch ->
           Log.debug (fun m -> m "writer %016x unlock our extension" uid);
           Clatch.count_down clatch
-      | None -> ()
+      | _ -> ()
     in
-    match Queue.peek t.active_writers with
-    | older ->
+    match Queue.peek t.active_processes with
+    | older, _ ->
         if uid = older then begin
-          assert (Queue.pop t.active_writers = uid);
+          assert (fst (Queue.pop t.active_processes) = uid);
           (* here, we possibly have few writers ahead our writer [uid]. they
              must have ended before us. *)
           Log.debug (fun m -> m "clean possible released writers");
-          unsafe_clean_released_writers t;
-          Option.value ~default:0 (Queue.peek_opt t.active_writers)
+          unsafe_clean_released_processes t;
+          let older = Queue.peek_opt t.active_processes in
+          let older = Option.map fst older in
+          Option.value ~default:0 older
         end
         else begin
           Log.debug (fun m ->
               m "it exists an older active writer (%016x) than %016x" older uid);
-          let rw = !(t.released_writers) in
+          let rw = !(t.released_processes) in
           let rw = Set.add uid rw in
-          t.released_writers := rw;
+          t.released_processes := rw;
           older
         end
     | exception Queue.Empty ->
         Log.err (fun m -> m "we missed writer %016x" uid);
         assert false
   in
-  update_older_active_writer ~older t
+  update_older_active_process ~older t
+
+let reader (t : t) fn =
+  let uid = Garbage_collector.gen () in
+  add_process t `Rd ~uid;
+  let reader =
+    { memory = Atomic.get t.memory; root = Rowex.Addr.to_rdonly t.root }
+  in
+  let res = try Ok (fn reader) with exn -> Error exn in
+  release_process t `Rd ~uid;
+  match res with Ok value -> value | Error exn -> raise exn
 
 let writer (t : t) fn =
   let writer : writer =
@@ -947,10 +954,10 @@ let writer (t : t) fn =
     ; free_locker = t.free_locker
     ; free = t.free
     ; free_cells = t.free_cells
-    ; older_active_writer = t.older_active_writer
+    ; older_active_process = t.older_active_process
     ; queue_locker = t.queue_locker
-    ; active_writers = t.active_writers
-    ; released_writers = t.released_writers
+    ; active_processes = t.active_processes
+    ; released_processes = t.released_processes
     ; clatch = t.clatch
     ; collected = t.collected
     ; extend_locker = t.extend_locker
@@ -961,7 +968,7 @@ let writer (t : t) fn =
     ; root = t.root
     }
   in
-  add_writer t ~uid:writer.uid;
+  add_process t `Wr ~uid:writer.uid;
   let res =
     try Ok (fn writer)
     with exn ->
@@ -970,5 +977,5 @@ let writer (t : t) fn =
             (Printexc.to_string exn));
       Error exn
   in
-  release_writer t ~uid:writer.uid;
+  release_process t `Wr ~uid:writer.uid;
   res

--- a/lib/part.ml
+++ b/lib/part.ml
@@ -857,7 +857,7 @@ let reader (rowex : t) =
 (* the goal here is to update [t.older_active_writer] to the one we get from
    [t.active_writers]. We **really try** to be synchrone between the last
    [t.active_writers] and [t.older_active_writer]. *)
-let rec update_older_activer_writer ?(backoff = Miou.Backoff.default) ?older
+let rec update_older_active_writer ?(backoff = Miou.Backoff.default) ?older
     (t : t) =
   let older =
     match older with
@@ -872,7 +872,7 @@ let rec update_older_activer_writer ?(backoff = Miou.Backoff.default) ?older
   if
     seen <> older
     && not (Atomic.compare_and_set t.older_active_writer seen older)
-  then update_older_activer_writer ~backoff:(Miou.Backoff.once backoff) t
+  then update_older_active_writer ~backoff:(Miou.Backoff.once backoff) t
 
 let add_writer (t : t) ~uid =
   Log.debug (fun m -> m "new writer %016x" uid);
@@ -884,7 +884,7 @@ let add_writer (t : t) ~uid =
       (* here, we take the previous writer before the apparition of our new one. *)
       Queue.peek t.active_writers
     in
-    update_older_activer_writer ~older t
+    update_older_active_writer ~older t
   end
   else
     Miou.Mutex.protect t.queue_locker @@ fun () ->
@@ -938,7 +938,7 @@ let release_writer (t : t) ~uid =
         Log.err (fun m -> m "we missed writer %016x" uid);
         assert false
   in
-  update_older_activer_writer ~older t
+  update_older_active_writer ~older t
 
 let writer (t : t) fn =
   let writer : writer =

--- a/lib/part.mli
+++ b/lib/part.mli
@@ -10,7 +10,7 @@ val exists : reader -> Rowex.key -> bool
 val remove : writer -> Rowex.key -> unit
 val insert : writer -> Rowex.key -> int -> unit
 val from_system : ?size:int -> string -> t
-val reader : t -> reader
+val reader : t -> (reader -> 'a) -> 'a
 val writer : t -> (writer -> 'a) -> ('a, exn) result
 (* {b NOTE}: The writer specified in the function is not {b shareable} and
    cannot be used across multiple domains. It must be assigned to a specific

--- a/lib/rowex.c
+++ b/lib/rowex.c
@@ -49,9 +49,21 @@ int ml_ctz(intnat x) {
 
 CAMLprim value caml_ctz(value n) { return (Val_long(ml_ctz(Long_val(n)))); }
 
+#include <caml/alloc.h>
+
 uint64_t caml_uint64_of_uint(value v) { return (Unsigned_long_val(v)); }
 
+CAMLprim value
+caml_bytecode_uint64_of_uint(value v) {
+  return caml_copy_int64(Unsigned_long_val(v));
+}
+
 uint32_t caml_uint32_of_uint(value v) { return (Unsigned_long_val(v)); }
+
+CAMLprim value
+caml_bytecode_uint32_of_uint(value v) {
+  return caml_copy_int32(Unsigned_long_val(v));
+}
 
 #if defined(ART_SSE2)
 #include <emmintrin.h>

--- a/lib/rowex.ml
+++ b/lib/rowex.ml
@@ -47,11 +47,11 @@ external bswap32 : int32 -> int32 = "%bswap_int32"
    primitives. *)
 
 external uint64_of_uint : int -> (int64[@unboxed])
-  = "bytecode_compilation_not_supported" "caml_uint64_of_uint"
+  = "caml_bytecode_uint64_of_uint" "caml_uint64_of_uint"
 [@@noalloc]
 
 external uint32_of_uint : int -> (int32[@unboxed])
-  = "bytecode_compilation_not_supported" "caml_uint32_of_uint"
+  = "caml_bytecode_uint32_of_uint" "caml_uint32_of_uint"
 [@@noalloc]
 
 let leintnat_to_string v =

--- a/lib/rowex.mli
+++ b/lib/rowex.mli
@@ -6,7 +6,20 @@ exception Duplicate
     atomically load and store values. This implementation wants to ensure 2
     things:
     - [insert] and [lookup] can be executed in {b true} parallelism
-    - persistence is ensured by required {i syscalls} *)
+    - persistence is ensured by required {i syscalls}
+
+    {2 A quick note about atomic operations.}
+
+    The "normal" model for our atomic operations is always the acquire/release
+    model for our variables. This corresponds to what a CPU can normally
+    consider if it complies with the TSO memory model (which is the case for an
+    [x86] processor). In the case of a CPU such as [ARM], it is necessary to
+    make this model explicit. However, there is an optimization where certain
+    writes can be relaxed. It is difficult to know the impact of such an
+    optimization: and to announce our ordering property as weak.
+
+    Thus, to simplify, we can consider that all loads have the acquire property
+    and all stores have the release property. *)
 
 type key = private string
 
@@ -80,6 +93,16 @@ module type S = sig
   *)
 
   val movnt64 : memory -> dst:'a wr Addr.t -> int -> unit t
+  (** [movnt64] is a special instruction that:
+      - must write bypassing the write cache
+      - must not load the page being written to in the cache
+
+      The goal here is that the write must be fundamentally persistent, but we
+      tolerate a cache miss if we try to read the modified page.
+
+      We tolerate this because [movnt64] is involved in creating a new node (and
+      therefore a new key insertion) that should not be read anytime soon. *)
+
   val set_n48_key : memory -> 'a wr Addr.t -> int -> int -> unit t
   val fetch_add : memory -> rdwr Addr.t -> (atomic, int) value -> int -> int t
   val fetch_or : memory -> rdwr Addr.t -> (atomic, int) value -> int -> int t


### PR DESCRIPTION
We must take into account active readers also when it's about sweep data from collected to free-ed data.